### PR TITLE
Set file permissions correctly when creating temp files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ m4/lt*.m4
 m4/libtool.m4
 .dirstamp
 .deps
+*.swp

--- a/src/ZHfstOspeller.cc
+++ b/src/ZHfstOspeller.cc
@@ -104,7 +104,8 @@ extract_to_tmp_dir(archive* ar, const char* filename, const std::string& tempdir
 {
     std::string rv = tempdir + "/" + std::string(filename);
     char* path = strdup(rv.c_str());
-    int32_t fd = open(path, O_WRONLY | O_CREAT);
+    // Create the file with read-only permissions for the current user (and process).
+    int32_t fd = open(path, O_WRONLY | O_CREAT, S_IRUSR);
     if (fd < 0)
     {
         throw ZHfstZipReadingError("Failed to open file descriptor");


### PR DESCRIPTION
According to the man page for `open(2)` you must provide a permissions mode when using the `O_CREAT` flag. I was getting permission-denied errors without this change as the file was being created unreadable and unwritable by anyone.

(also added a gitignore pattern for vim swap files, which often get in my way)